### PR TITLE
Add Bandit workflow

### DIFF
--- a/.github/workflow/bandit.yml
+++ b/.github/workflow/bandit.yml
@@ -1,0 +1,26 @@
+name: Bandit
+
+on: [push]
+
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install bandit pandas pyyaml
+      - name: Run Bandit
+        run: |
+          bandit -r . -x tests


### PR DESCRIPTION
## Summary
- add Bandit security scanning workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847c4973270832eb3a678c333b9ff67