### PR TITLE
Add raw text columns and improved difference formatting

### DIFF
--- a/tests/test_compare_sti.py
+++ b/tests/test_compare_sti.py
@@ -71,8 +71,14 @@ def test_sti_matrix_load(tmp_path, monkeypatch):
     monkeypatch.setattr(pd, "read_excel", fake_read_excel)
     matrix = cs.STIMatrix(defn, cfg.fields_to_compare)
     df = matrix.load()
-    assert set(df.columns) == {"Reference", "Requirement", "MOP_design"}
+    assert set(df.columns) == {
+        "Reference",
+        "Requirement",
+        "MOP_design",
+        "MOP_design_raw",
+    }
     assert df.loc[0, "MOP_design"] == {"DID1234567890"}
+    assert df.loc[0, "MOP_design_raw"] == "blah DID1234567890"
 
 
 def test_sti_matrix_load_missing_column(tmp_path, monkeypatch):
@@ -89,6 +95,7 @@ def test_sti_matrix_load_missing_column(tmp_path, monkeypatch):
     df = matrix.load()
     # Missing column should be filled with NA
     assert df.loc[0, "MOP_design"] == set()
+    assert pd.isna(df.loc[0, "MOP_design_raw"])
 
 
 def test_ppd_checker(monkeypatch, tmp_path):
@@ -135,6 +142,22 @@ def test_compare():
     )
     diffs = cmp.compare(df1, df2)
     assert len(diffs) == 3
+
+
+def test_compare_raw_difference():
+    cmp = cs.STIMatrixComparator(["MOP_design"])
+    df1 = pd.DataFrame({
+        "Reference": [1],
+        "MOP_design": [{"ID1"}],
+        "MOP_design_raw": ["a ID1"],
+    })
+    df2 = pd.DataFrame({
+        "Reference": [1],
+        "MOP_design": [{"ID2"}],
+        "MOP_design_raw": ["b ID2"],
+    })
+    diffs = cmp.compare(df1, df2)
+    assert diffs.loc[0, "Différence"] == "a ID1 -> b ID2"
 
 
 def test_compare_no_difference():
@@ -247,6 +270,39 @@ def test_main_output_too_large(monkeypatch, tmp_path):
     cs.main()
     assert path_holder["path"] == output.with_suffix(".csv")
     assert any("Differences written" in line for line in out)
+
+
+def test_main_prints_differences(monkeypatch, tmp_path):
+    path = make_config(tmp_path)
+
+    def fake_parse_args():
+        return SimpleNamespace(
+            matrix1="A",
+            matrix2="B",
+            config=str(path),
+            output=None,
+            ppd=None,
+        )
+
+    monkeypatch.setattr(cs.argparse.ArgumentParser, "parse_args", staticmethod(fake_parse_args))
+    monkeypatch.setattr(pd, "read_excel", lambda *a, **k: pd.DataFrame())
+    monkeypatch.setattr(cs.STIMatrix, "load", lambda self: pd.DataFrame({"Reference": [1]}))
+    monkeypatch.setattr(
+        cs.STIMatrixComparator,
+        "compare",
+        lambda self, a, b: pd.DataFrame({
+            "Reference": [1],
+            "field": ["Requirement"],
+            "value_1": ["A"],
+            "value_2": ["B"],
+            "Différence": ["A -> B"],
+        }),
+    )
+
+    out = []
+    monkeypatch.setattr(builtins, "print", lambda *a, **k: out.append(" ".join(map(str, a))))
+    cs.main()
+    assert any("A -> B" in line for line in out)
 
 
 def test_main_missing_ppd(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- retain raw text before extracting document IDs in `STIMatrix.load`
- include a `Différence` column using this raw text when comparing matrices
- cover new behaviour in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847df3745ec832e8a7d97e04eb36256